### PR TITLE
Re-added support for Proton 5.0-10 and older

### DIFF
--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -20,6 +20,12 @@ done
 gamecmd=("${protoncmd[@]:2}")
 protoncmd=("${protoncmd[@]:0:2}")
 
+# If no -- is detected, we're probably running Proton 5.0-10 or older
+if [ -z "${protoncmd}" ]; then
+    protoncmd=("${@:1:2}")
+    gamecmd=("${@:3}")
+fi
+
 "${protoncmd[@]}" "$BRIDGE" &
 sleep $DELAY
 "${protoncmd[@]//waitforexitandrun/run}" "${gamecmd[@]}"


### PR DESCRIPTION
Some games run much better with 5.0 or older - probably related to containers but I haven't looked into it.

Proton versions 5.0 and older don't use -- when executing so I effectively check for this. Tested the script with Proton 5.0-10 and 5.13-4 launching the same game in steam - works great