### PR TITLE
winediscordipcbridge-steam.sh won't work on most Debian based systems

### DIFF
--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Run a Steam Play game with wine-discord-ipc-bridge
 # Set the game's launch option to: path/to/this-script.sh %command%


### PR DESCRIPTION
Thank you for this project. Works great with one small caveat. Most Debian based systems as of late link /bin/sh to /bin/dash which doesn't support ${BASH_SOURCE[0]}. Because of that the script won't work as is.

Simply switching line 1 from #!/bin/sh to #!/bin/bash fixes the issue.

After that the script works flawlessly on my Ubuntu 20.04 system.