### PR TITLE
Throw clear error for user if no wine version is specified

### DIFF
--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -6,6 +6,11 @@
 BRIDGE="$(dirname ${BASH_SOURCE[0]})/winediscordipcbridge.exe" # Set BRIDGE to the path of winediscordipcbridge.exe
 DELAY=5
 
+if [[ $1 == "" ]]; then
+    echo "Error: please specify argument after script (EX: ./winedriscordipcbridge-steam.sh wine")
+    exit 1
+fi
+
 # Extract and run the proton command without the steam runtime container (see #8)
 runtimecmd=()
 protoncmd=()


### PR DESCRIPTION
instead of having the script try and run "./winediscordipcbridge.exe" and failing, leaving the user confused as to why the hell it's trying to run a .exe like that, it explains that an argument is needed