### PR TITLE
Add /run/user/$UID to possible IPC Paths

### DIFF
--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -23,6 +23,7 @@ DISCORD_IPC_PATHS=(
     "$TEMP_PATH/app/com.discordapp.Discord"
     "$TEMP_PATH/snap.discord-canary"
     "$TEMP_PATH/snap.discord"
+    "run/user/$UID"
 )
 
 for ipc_path in "${DISCORD_IPC_PATHS[@]}"; do

--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -23,7 +23,7 @@ DISCORD_IPC_PATHS=(
     "$TEMP_PATH/app/com.discordapp.Discord"
     "$TEMP_PATH/snap.discord-canary"
     "$TEMP_PATH/snap.discord"
-    "run/user/$UID"
+    "/run/user/$UID"
 )
 
 for ipc_path in "${DISCORD_IPC_PATHS[@]}"; do


### PR DESCRIPTION
After a bit of research, i've found out that Discord added their discord-ipc-? file to that path for me.
This PR should fix rich presences not appearing for some people