### PR TITLE
Update winediscordipcbridge-steam.sh

### DIFF
--- a/winediscordipcbridge-steam.sh
+++ b/winediscordipcbridge-steam.sh
@@ -23,6 +23,7 @@ DISCORD_IPC_PATHS=(
     "$TEMP_PATH/app/com.discordapp.Discord"
     "$TEMP_PATH/snap.discord-canary"
     "$TEMP_PATH/snap.discord"
+    "$TEMP_PATH/usr/bin/discord"
     "/run/user/$UID"
 )
 


### PR DESCRIPTION
Added support for non-snap, non-flatpak-version of discord by adding temp path: /usr/bin/discord